### PR TITLE
Update CMakeLists for simpler content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,12 @@
 cmake_minimum_required(VERSION 3.0.0)
-project(he_basic_app VERSION 0.1.0)
-
-include(CTest)
-enable_testing()
+project(he_basic_app)
 
 add_executable(he_basic_app main.cpp)
+target_link_libraries(he_basic_app ${CMAKE_DL_LIBS})
 
-set(CPACK_PROJECT_NAME ${PROJECT_NAME})
-set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
-include(CPack)
 if(WIN32)
-    include_directories(X:/HOOPS_Exchange_Publish_2021_SP2_U2/include)
-else(WIN32)
-    include_directories(/opt/local/ts3d/HOOPS_Exchange_2021_SP2_U2/include)
-    add_link_options(he_basic_app -ldl)
-endif(WIN32)
+    target_include_directories(he_basic_app "X:/HOOPS_Exchange_Publish_2021_SP2_U2/include")
+else()
+    target_include_directories(he_basic_app "/opt/local/ts3d/HOOPS_Exchange_2021_SP2_U2/include")
+endif()
+


### PR DESCRIPTION
- There's no need for CPack or testing unless this CMakeLists is part of a bigger project. But in this case those commands should be in a higher level CMakeLists.
- Project version is not mandatory
- target_include_directories in preferable over include_directories.
- Use CMAKE_DL_LIBS instead of explicit library name to stay platform neutral (expands to nothing in Windows)